### PR TITLE
Y axis graduations improvement

### DIFF
--- a/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
+++ b/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
@@ -67,12 +67,18 @@ internal class LineGraphHelper(
         val absMaxY = GraphHelper.getAbsoluteMax(yAxisData)
         val absMinY = 0
 
-        val verticalStep = absMaxY.toInt() / maxPointsSize.toFloat()
+        // prevents having repetitions of y labels when y data are all low values
+        val numberOfVerticalSteps =
+            if (yAxisData.contains(0))
+                yAxisData.distinct().size - 1
+            else
+                yAxisData.distinct().size
+        val verticalStep = absMaxY.toInt() / numberOfVerticalSteps.toFloat()
 
         // generate y axis label
         val yAxisLabelList = mutableListOf<String>()
 
-        for (i in 0..maxPointsSize) {
+        for (i in 0..numberOfVerticalSteps) {
             val intervalValue = (verticalStep*i).roundToInt()
             logDebug(message = "interval - $intervalValue")
             yAxisLabelList.add(intervalValue.toString())

--- a/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
+++ b/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
@@ -67,7 +67,7 @@ internal class LineGraphHelper(
         val absMaxY = GraphHelper.getAbsoluteMax(yAxisData)
         val absMinY = 0
 
-        // prevents having repetitions of y labels when y data are all low values
+        // prevent duplication of y labels when yAxisData list has same values
         val numberOfVerticalSteps =
             if (yAxisData.contains(0))
                 yAxisData.distinct().size - 1


### PR DESCRIPTION
Fixes Y axis graduations when Y values are all low numbers or when they include 0.

Example using Y values 1, 3, 2, 0, 1, 3, 2 
Before 
![before](https://github.com/jaikeerthick/Composable-Graphs/assets/58014447/1fe06a74-dc17-423f-879d-72b8c6e8d49f)
After
![after](https://github.com/jaikeerthick/Composable-Graphs/assets/58014447/0ad1ed12-9d0f-4511-b8df-ef9f18f5b22b)
