### PR TITLE
[refactor] Use ceil to calculate y-axis step

### DIFF
--- a/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
+++ b/composable-graphs/src/main/java/com/jaikeerthick/composable_graphs/composables/line/LineGraphHelper.kt
@@ -17,6 +17,7 @@ import com.jaikeerthick.composable_graphs.util.GraphHelper
 import com.jaikeerthick.composable_graphs.style.LabelPosition
 import com.jaikeerthick.composable_graphs.composables.line.style.LineGraphStyle
 import com.jaikeerthick.composable_graphs.util.logDebug
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 
 internal data class LineGraphMetrics(
@@ -80,7 +81,7 @@ internal class LineGraphHelper(
             if (absMaxY == 0)
                 1F
             else
-                absMaxY.toInt() / numberOfVerticalSteps.toFloat()
+                ceil(absMaxY.toDouble()).toInt() / numberOfVerticalSteps.toFloat()
 
         // generate y axis label
         val yAxisLabelList = mutableListOf<String>()


### PR DESCRIPTION
Uses `ceil` to round up the maximum Y value before calculating the step size for the y-axis labels. This prevents potential rounding issues and ensures more accurate axis graduation.